### PR TITLE
try fixing detached head and set fetch-depth to all history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          # all history is needed to crawl it properly
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -15,7 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          # all history is needed to crawl it properly
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # all history is needed to crawl it properly
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -14,8 +14,13 @@ jobs:
   test-and-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # all history is needed to crawl it properly
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v3
         with:
           python-version: '3.11'
       - name: Execute tests

--- a/snippets2changelog/collector.py
+++ b/snippets2changelog/collector.py
@@ -38,8 +38,12 @@ class HistoryWalker(object):
         return Path(self._repo.working_dir)
 
     @property
-    def branch_name(self) -> Head:
-        return self._repo.active_branch
+    def branch_name(self) -> str:
+        try:
+            return str(self._repo.active_branch)
+        except Exception as e:
+            print(f"HEAD is detached: {e}")
+            return str(self._repo.head.commit.hexsha)
 
     @property
     def tags(self) -> list[TagReference]:


### PR DESCRIPTION
Use `actions/checkout@v3` in all workflows and set `fetch-depth: 0` to get all history for all branches and tags.

Name steps where not yet named.

Fallback to `return str(self._repo.head.commit.hexsha)` on `branch_name` function if in detached head