### PR TITLE
fix automatic snippet release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,15 @@ jobs:
           python -m pip install -U poetry twine
           poetry self add "poetry-dynamic-versioning[plugin]"
           poetry install
+      - name: Update changelog with snippets
+        run: |
+          poetry run changelog-generator \
+            changelog changelog.md \
+            --snippets=.snippets
       - name: Parse changelog
         id: parse_changelog
         run: |
-          poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
+          poetry run changelog2version --changelog_file changelog.md.new --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
@@ -42,9 +47,6 @@ jobs:
           echo "latest_version=$latest_version" >> $GITHUB_ENV
       - name: Build package
         run: |
-          poetry run changelog-generator \
-            changelog changelog.md \
-            --snippets=.snippets
           poetry run changelog2version \
             --changelog_file changelog.md.new \
             --version_file snippets2changelog/version.py \

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -28,10 +28,15 @@ jobs:
           python -m pip install -U poetry twine
           poetry self add "poetry-dynamic-versioning[plugin]"
           poetry install
+      - name: Update changelog with snippets
+        run: |
+          poetry run changelog-generator \
+            changelog changelog.md \
+            --snippets=.snippets
       - name: Parse changelog
         id: parse_changelog
         run: |
-          poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
+          poetry run changelog2version --changelog_file changelog.md.new --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
@@ -39,9 +44,6 @@ jobs:
           echo "latest_version=$latest_version" >> $GITHUB_ENV
       - name: Build package
         run: |
-          poetry run changelog-generator \
-            changelog changelog.md \
-            --snippets=.snippets
           poetry run changelog2version \
             --changelog_file changelog.md.new \
             --version_file snippets2changelog/version.py \

--- a/.snippets/5.md
+++ b/.snippets/5.md
@@ -1,0 +1,17 @@
+## Fix automatic snippet release
+<!--
+type: bugfix
+scope: internal
+affected: all
+-->
+
+### Added
+- New `Update changelog with snippets` step in `release` and `test-release` workflow to create changelog before any onwards parsing steps
+- Function `branch_name` of `snippets2changelog/collector.py` falls back to `return str(self._repo.head.commit.hexsha)` if in detached head mode
+
+### Changed
+- Set `fetch-depth: 0` to get all history for all branches and tags
+
+### Fixed
+- All GitHub workflows use `actions/checkout@v3`
+- Parse new changelog file `changelog.md.new` in `test-release` and `release` workflow


### PR DESCRIPTION
### Added
- New `Update changelog with snippets` step in `release` and `test-release` workflow to create changelog before any onwards parsing steps
- Function `branch_name` of `snippets2changelog/collector.py` falls back to `return str(self._repo.head.commit.hexsha)` if in detached head mode

### Changed
- Set `fetch-depth: 0` to get all history for all branches and tags

### Fixed
- All GitHub workflows use `actions/checkout@v3`
- Parse new changelog file `changelog.md.new` in `test-release` and `release` workflow
