### PR TITLE
get latest_version content from changelog.md.new

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          latest_version=$(poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+          latest_version=$(poetry run changelog2version --changelog_file changelog.md.new --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
           echo "latest_version=$latest_version" >> $GITHUB_ENV
       - name: Build package
         run: |

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -40,7 +40,7 @@ jobs:
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          latest_version=$(poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+          latest_version=$(poetry run changelog2version --changelog_file changelog.md.new --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
           echo "latest_version=$latest_version" >> $GITHUB_ENV
       - name: Build package
         run: |

--- a/.snippets/6.md
+++ b/.snippets/6.md
@@ -1,0 +1,9 @@
+## Fix parsing of latest_version info
+<!--
+type: bugfix
+scope: internal
+affected: all
+-->
+
+### Fixed
+- `latest_version` is also parsed from `changelog.md.new` instead of `changelog.md`. This enables automatic GitHub release creation again.


### PR DESCRIPTION
### Fixed
- `latest_version` is also parsed from `changelog.md.new` instead of `changelog.md`. This enables automatic GitHub release creation again.
