### PR TITLE
enable in-place updates of a changelog file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,20 +35,21 @@ jobs:
         run: |
           poetry run changelog-generator \
             changelog changelog.md \
-            --snippets=.snippets
+            --snippets=.snippets \
+            --in-place
       - name: Parse changelog
         id: parse_changelog
         run: |
-          poetry run changelog2version --changelog_file changelog.md.new --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
+          poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          latest_version=$(poetry run changelog2version --changelog_file changelog.md.new --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+          latest_version=$(poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
           echo "latest_version=$latest_version" >> $GITHUB_ENV
       - name: Build package
         run: |
           poetry run changelog2version \
-            --changelog_file changelog.md.new \
+            --changelog_file changelog.md \
             --version_file snippets2changelog/version.py \
             --version_file_type py \
             --debug

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -32,20 +32,21 @@ jobs:
         run: |
           poetry run changelog-generator \
             changelog changelog.md \
-            --snippets=.snippets
+            --snippets=.snippets \
+            --in-place
       - name: Parse changelog
         id: parse_changelog
         run: |
-          poetry run changelog2version --changelog_file changelog.md.new --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
+          poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          latest_version=$(poetry run changelog2version --changelog_file changelog.md.new --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+          latest_version=$(poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
           echo "latest_version=$latest_version" >> $GITHUB_ENV
       - name: Build package
         run: |
           poetry run changelog2version \
-            --changelog_file changelog.md.new \
+            --changelog_file changelog.md \
             --version_file snippets2changelog/version.py \
             --version_file_type py \
             --additional_version_info="-rc${{ github.run_number }}.dev${{ github.event.number }}" \

--- a/.snippets/9.md
+++ b/.snippets/9.md
@@ -1,0 +1,13 @@
+## Enable in-place updates of a changelog file
+<!--
+type: feature
+scope: all
+affected: all
+-->
+
+The `changelog-generator` command can be used with the `--in-place` flag to
+update a changelog file in-place instead of generating a new changelog file
+named `*.new`.
+This option is intended for CI usage as multiple runs on a already updated
+changelog can lead to unintended version bumps.
+This option is now used in the Github Actions of this project.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,16 @@ TBD
 #### Changelog
 
 Create or update a changelog with all snippets.
-New changelog will be named `<OLD_CHANGELOG_NAME.new>`
+
+The generated changelog will be named `<OLD_CHANGELOG_NAME.new>` unless the
+`--in-place` flag is used. This flag is intended for CI usage with a clean
+checkout before a run.
+
+*Be aware to restore the changelog before another run as it might generate
+version entries and version bumps multiple times otherwise.*
 
 ```bash
-changelog-generator changelog changelog.md --snippets=.snippets
+changelog-generator changelog changelog.md --snippets=.snippets [--in-place]
 ```
 
 ### Parse

--- a/snippets2changelog/cli.py
+++ b/snippets2changelog/cli.py
@@ -65,6 +65,11 @@ def parse_args(argv: Sequence[str] | None = None) -> Args:
         type=lambda x: does_exist(parser, x),
         help="Directory to crawl for snippets",
     )
+    parser_changelog.add_argument(
+        "--in-place",
+        action='store_true',
+        help="Update specified changelog in place",
+    )
 
     parser_create = subparsers.add_parser(
         "create",
@@ -114,7 +119,7 @@ def fn_info(_args: Args) -> None:
 
 
 def fn_changelog(args: Args) -> None:
-    cc = ChangelogCreator(changelog=args.changelog, snippets_folder=args.snippets, verbosity=args.verbose)
+    cc = ChangelogCreator(changelog=args.changelog, snippets_folder=args.snippets, update_in_place=args.in_place, verbosity=args.verbose)
     cc.update_changelog()
 
 

--- a/snippets2changelog/creator.py
+++ b/snippets2changelog/creator.py
@@ -64,9 +64,10 @@ class SnippetCreator(object):
 class ChangelogCreator(ExtractVersion, SnippetParser, SnippetCreator, SnippetCollector):  # type: ignore
     """docstring for ChangelogCreator"""
 
-    def __init__(self, changelog: Path,  snippets_folder: Path, verbosity: int = 0) -> None:
+    def __init__(self, changelog: Path,  snippets_folder: Path, update_in_place: bool, verbosity: int = 0) -> None:
         if changelog.exists():
             self._changelog = changelog
+            self._update_in_place = update_in_place
         else:
             raise ChangelogCreatorError(f"Given changelog '{changelog}' does not exist")
 
@@ -118,5 +119,7 @@ class ChangelogCreator(ExtractVersion, SnippetParser, SnippetCreator, SnippetCol
             new_changelog_content = changelog_entry + new_changelog_content
 
         rendered_changelog = self._env.get_template("changelog.md.template").render({"prolog": existing_changelog_content[0], "new": new_changelog_content, "existing": self._version_line + existing_changelog_content[1]})
-        rendered_changelog_path = Path(f"{self._changelog}.new")
+        rendered_changelog_path = Path(f"{self._changelog}")
+        if not self._update_in_place:
+            rendered_changelog_path = Path(str(rendered_changelog_path) + ".new")
         save_file(content=rendered_changelog, path=rendered_changelog_path)


### PR DESCRIPTION
The `changelog-generator` command can be used with the `--in-place` flag to update a changelog file in-place instead of generating a new changelog file named `*.new`.
This option is intended for CI usage as multiple runs on a already updated changelog can lead to unintended version bumps.
This option is now used in the Github Actions of this project.