### PR TITLE
Add meta data as comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # snippets2changelog specific
 changelog.md.new
 
+# changelog2version specific
+changelog.json
+
 # custom, package specific ignores
 .DS_Store
 .DS_Store?

--- a/.snippets/16.md
+++ b/.snippets/16.md
@@ -1,0 +1,9 @@
+## Add comment with meta data below every changelog entry
+<!--
+type: feature
+scope: all
+affected: all
+-->
+
+- add comment with meta data below every changelog entry for later parsing, closes #16
+- update `README` badge to show support for Python 3.9 - 3.11 instead of generic Python 3

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Downloads](https://pepy.tech/badge/snippets2changelog)](https://pepy.tech/project/snippets2changelog)
 ![Release](https://img.shields.io/github/v/release/brainelectronics/snippets2changelog?include_prereleases&color=success)
-![Python](https://img.shields.io/badge/python3-Ok-green.svg)
+![Python](https://img.shields.io/badge/Python-3.9%20|%203.10%20|%203.11-green.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/github/brainelectronics/snippets2changelog/branch/main/graph/badge.svg)](https://app.codecov.io/github/brainelectronics/snippets2changelog)
 

--- a/snippets2changelog/creator.py
+++ b/snippets2changelog/creator.py
@@ -109,6 +109,11 @@ class ChangelogCreator(ExtractVersion, SnippetParser, SnippetCreator, SnippetCol
             changelog_entry_content = {
                 "version": self.semver_data,
                 "timestamp": commit.committed_datetime.isoformat(),
+                "meta": {
+                    "type": snippet_content["type"],
+                    "scope": snippet_content["scope"],
+                    "affected": snippet_content["affected"],
+                },
                 "content": snippet_content["details"],
                 "version_reference": f"https://github.com/brainelectronics/snippets2changelog/tree/{self.semver_data}",
             }

--- a/snippets2changelog/templates/changelog_part.md.template
+++ b/snippets2changelog/templates/changelog_part.md.template
@@ -1,4 +1,7 @@
 ## [{{ version }}] - {{ timestamp }}
+{%- if meta %}
+<!-- meta = {{ meta }} -->
+{%- endif %}
 {{- content }}
 [{{ version }}]: {{ version_reference }}
 


### PR DESCRIPTION
- add comment with meta data below every changelog entry for later parsing, closes #16
- update `README` badge to show support for Python 3.9 - 3.11 instead of generic Python 3
