### PR TITLE
add --no-internal option

### DIFF
--- a/.snippets/21.md
+++ b/.snippets/21.md
@@ -1,0 +1,11 @@
+## Add option to skip snippets marked as 'internal'
+<!--
+type: feature
+scope: all
+affected: all
+-->
+
+This adds the option `--no-internal` to skip snippets with scope `internal`
+during the changelog generation. This change explicitly does not add a
+documentation to the `README` file to show and test this behaviour in a second
+pull request.

--- a/snippets2changelog/cli.py
+++ b/snippets2changelog/cli.py
@@ -70,6 +70,11 @@ def parse_args(argv: Union[Sequence[str], None] = None) -> Args:
         action='store_true',
         help="Update specified changelog in place",
     )
+    parser_changelog.add_argument(
+        "--no-internal",
+        action='store_true',
+        help="Skip snippets with scope set as 'internal'",
+    )
 
     parser_create = subparsers.add_parser(
         "create",
@@ -119,7 +124,7 @@ def fn_info(_args: Args) -> None:
 
 
 def fn_changelog(args: Args) -> None:
-    cc = ChangelogCreator(changelog=args.changelog, snippets_folder=args.snippets, update_in_place=args.in_place, verbosity=args.verbose)
+    cc = ChangelogCreator(changelog=args.changelog, snippets_folder=args.snippets, update_in_place=args.in_place, skip_internal=args.no_internal, verbosity=args.verbose)
     cc.update_changelog()
 
 

--- a/snippets2changelog/creator.py
+++ b/snippets2changelog/creator.py
@@ -64,7 +64,7 @@ class SnippetCreator(object):
 class ChangelogCreator(ExtractVersion, SnippetParser, SnippetCreator, SnippetCollector):  # type: ignore
     """docstring for ChangelogCreator"""
 
-    def __init__(self, changelog: Path,  snippets_folder: Path, update_in_place: bool, verbosity: int = 0) -> None:
+    def __init__(self, changelog: Path,  snippets_folder: Path, update_in_place: bool, skip_internal: bool = False, verbosity: int = 0) -> None:
         if changelog.exists():
             self._changelog = changelog
             self._update_in_place = update_in_place
@@ -87,6 +87,8 @@ class ChangelogCreator(ExtractVersion, SnippetParser, SnippetCreator, SnippetCol
         self._logger.debug(("semver_data:", self.semver_data))
         # VersionInfo(major=0, minor=1, patch=0, prerelease=None, build=None))
 
+        self._skip_internal = skip_internal
+
     def update_changelog(self) -> None:
         new_changelog_content = ""
         # create a "prolog" and an "epilog", with the new content in between
@@ -97,6 +99,10 @@ class ChangelogCreator(ExtractVersion, SnippetParser, SnippetCreator, SnippetCol
             self.parse(file_name=file_name)
             snippet_content = self.parsed_content
             self._logger.debug(snippet_content)
+
+            if "internal" in snippet_content["scope"] and self._skip_internal:
+                continue
+
             if snippet_content["type"] == "bugfix":
                 self.semver_data = self.semver_data.bump_patch()
             elif snippet_content["type"] == "feature":


### PR DESCRIPTION
This adds the option `--no-internal` to skip snippets with scope `internal` during the changelog generation. This change explicitly does not add a documentation to the `README` file to show and test this behaviour in a second pull request.