### PR TITLE
Document and use no-internal option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,18 @@ jobs:
           python -m pip install -U poetry twine
           poetry self add "poetry-dynamic-versioning[plugin]"
           poetry install
+      - name: Parse changelog
+        id: parse_changelog
+        run: |
+          poetry run changelog-generator \
+            changelog changelog.md \
+            --snippets=.snippets \
+            --dry-run > latest-entry.json
+          echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
+          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
+          jq -r ".content" latest-entry.json >> $GITHUB_OUTPUT
+          echo '"EOT"' >> $GITHUB_OUTPUT
+          echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \
@@ -38,21 +50,7 @@ jobs:
             --snippets=.snippets \
             --in-place \
             --no-internal
-      - name: Parse changelog
-        id: parse_changelog
-        run: |
-          poetry run changelog2version \
-            --changelog_file changelog.md \
-            --output changelog.json \
-            --print \
-            --debug
-          echo "CHANGELOG_JSON=$(jq -c . < changelog.json)" >> $GITHUB_ENV
-          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          jq -r ".info.description" changelog.json >> $GITHUB_OUTPUT
-          echo '"EOT"' >> $GITHUB_OUTPUT
-          echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           poetry run changelog2version \
             --changelog_file changelog.md \
@@ -61,7 +59,7 @@ jobs:
             --debug
           poetry build
       - name: Publish package
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -69,7 +67,7 @@ jobs:
           verbose: true
           print_hash: true
       - name: Create Release
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           echo '"EOT"' >> $GITHUB_OUTPUT
           echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
-        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           poetry run changelog2version \
             --changelog_file changelog.md \
@@ -61,7 +61,7 @@ jobs:
             --debug
           poetry build
       - name: Publish package
-        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
           verbose: true
           print_hash: true
       - name: Create Release
-        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,10 @@ jobs:
             changelog changelog.md \
             --snippets=.snippets \
             --dry-run > latest-entry.json
+          jq -r ".content" latest-entry.json > latest_description.txt
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          jq -r ".content" latest-entry.json >> $GITHUB_OUTPUT
+          cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
           echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
           poetry run changelog-generator \
             changelog changelog.md \
             --snippets=.snippets \
-            --in-place
+            --in-place \
+            --no-internal
       - name: Parse changelog
         id: parse_changelog
         run: |
@@ -51,6 +52,7 @@ jobs:
           echo '"EOT"' >> $GITHUB_OUTPUT
           echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
+        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           poetry run changelog2version \
             --changelog_file changelog.md \
@@ -59,6 +61,7 @@ jobs:
             --debug
           poetry build
       - name: Publish package
+        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -66,6 +69,7 @@ jobs:
           verbose: true
           print_hash: true
       - name: Create Release
+        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,9 @@ jobs:
             --debug
           echo "CHANGELOG_JSON=$(jq -c . < changelog.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          jq ".info.description" changelog.json >> $GITHUB_OUTPUT
+          jq -r ".info.description" changelog.json >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          echo "latest_version=$(jq '.info.version' changelog.json)" >> $GITHUB_ENV
+          echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
         run: |
           poetry run changelog2version \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,16 @@ jobs:
       - name: Parse changelog
         id: parse_changelog
         run: |
-          poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
+          poetry run changelog2version \
+            --changelog_file changelog.md \
+            --output changelog.json \
+            --print \
+            --debug
+          echo "CHANGELOG_JSON=$(jq -c . < changelog.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          cat latest_description.txt >> $GITHUB_OUTPUT
+          jq ".info.description" changelog.json >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          latest_version=$(poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
-          echo "latest_version=$latest_version" >> $GITHUB_ENV
+          echo "latest_version=$(jq '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
         run: |
           poetry run changelog2version \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
             --snippets=.snippets \
             --dry-run > latest-entry.json
           jq -r ".content" latest-entry.json > latest_description.txt
+          sed -i '/^$/d' latest_description.txt
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -49,7 +49,7 @@ jobs:
           echo '"EOT"' >> $GITHUB_OUTPUT
           echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
-        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           poetry run changelog2version \
             --changelog_file changelog.md \
@@ -59,11 +59,11 @@ jobs:
             --debug
           poetry build
       - name: Test built package
-        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           twine check dist/*.tar.gz
       - name: Archive build package artifact
-        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: actions/upload-artifact@v4
         with:
           # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
@@ -72,7 +72,7 @@ jobs:
           path: dist/*.tar.gz
           retention-days: 14
       - name: Publish package
-        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           repository_url: https://test.pypi.org/legacy/
@@ -81,7 +81,7 @@ jobs:
           verbose: true
           print_hash: true
       - name: Create Prerelease
-        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -36,7 +36,6 @@ jobs:
             --snippets=.snippets \
             --dry-run > latest-entry.json
           jq -r ".content" latest-entry.json > latest_description.txt
-          sed -i '/^$/d' latest_description.txt
           cat latest-entry.json
           cat latest_description.txt
       - name: Update changelog with snippets

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -36,6 +36,7 @@ jobs:
             --snippets=.snippets \
             --dry-run > latest-entry.json
           jq -r ".content" latest-entry.json > latest_description.txt
+          sed -i '/^$/d' latest_description.txt
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -44,9 +44,9 @@ jobs:
             --debug
           echo "CHANGELOG_JSON=$(jq -c . < changelog.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          jq ".info.description" changelog.json >> $GITHUB_OUTPUT
+          jq -r ".info.description" changelog.json >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          echo "latest_version=$(jq '.info.version' changelog.json)" >> $GITHUB_ENV
+          echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
         run: |
           poetry run changelog2version \

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -35,9 +35,10 @@ jobs:
             changelog changelog.md \
             --snippets=.snippets \
             --dry-run > latest-entry.json
+          jq -r ".content" latest-entry.json > latest_description.txt
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          jq -r ".content" latest-entry.json >> $GITHUB_OUTPUT
+          cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
           echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -37,12 +37,16 @@ jobs:
       - name: Parse changelog
         id: parse_changelog
         run: |
-          poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['description'])" > latest_description.txt
+          poetry run changelog2version \
+            --changelog_file changelog.md \
+            --output changelog.json \
+            --print \
+            --debug
+          echo "CHANGELOG_JSON=$(jq -c . < changelog.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          cat latest_description.txt >> $GITHUB_OUTPUT
+          jq ".info.description" changelog.json >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          latest_version=$(poetry run changelog2version --changelog_file changelog.md --print | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
-          echo "latest_version=$latest_version" >> $GITHUB_ENV
+          echo "latest_version=$(jq '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
         run: |
           poetry run changelog2version \

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -28,6 +28,18 @@ jobs:
           python -m pip install -U poetry twine
           poetry self add "poetry-dynamic-versioning[plugin]"
           poetry install
+      - name: Parse changelog
+        id: parse_changelog
+        run: |
+          poetry run changelog-generator \
+            changelog changelog.md \
+            --snippets=.snippets \
+            --dry-run > latest-entry.json
+          echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
+          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
+          jq -r ".content" latest-entry.json >> $GITHUB_OUTPUT
+          echo '"EOT"' >> $GITHUB_OUTPUT
+          echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \
@@ -35,21 +47,7 @@ jobs:
             --snippets=.snippets \
             --in-place \
             --no-internal
-      - name: Parse changelog
-        id: parse_changelog
-        run: |
-          poetry run changelog2version \
-            --changelog_file changelog.md \
-            --output changelog.json \
-            --print \
-            --debug
-          echo "CHANGELOG_JSON=$(jq -c . < changelog.json)" >> $GITHUB_ENV
-          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          jq -r ".info.description" changelog.json >> $GITHUB_OUTPUT
-          echo '"EOT"' >> $GITHUB_OUTPUT
-          echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           poetry run changelog2version \
             --changelog_file changelog.md \
@@ -59,11 +57,9 @@ jobs:
             --debug
           poetry build
       - name: Test built package
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           twine check dist/*.tar.gz
       - name: Archive build package artifact
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: actions/upload-artifact@v4
         with:
           # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
@@ -72,7 +68,7 @@ jobs:
           path: dist/*.tar.gz
           retention-days: 14
       - name: Publish package
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           repository_url: https://test.pypi.org/legacy/
@@ -81,7 +77,7 @@ jobs:
           verbose: true
           print_hash: true
       - name: Create Prerelease
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -35,6 +35,10 @@ jobs:
             changelog changelog.md \
             --snippets=.snippets \
             --dry-run > latest-entry.json
+          jq -r ".content" latest-entry.json > latest_description.txt
+          sed -i '/^$/d' latest_description.txt
+          cat latest-entry.json
+          cat latest_description.txt
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -38,10 +38,6 @@ jobs:
           jq -r ".content" latest-entry.json > latest_description.txt
           sed -i '/^$/d' latest_description.txt
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
-          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          cat latest_description.txt >> $GITHUB_OUTPUT
-          echo '"EOT"' >> $GITHUB_OUTPUT
-          echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -33,7 +33,8 @@ jobs:
           poetry run changelog-generator \
             changelog changelog.md \
             --snippets=.snippets \
-            --in-place
+            --in-place \
+            --no-internal
       - name: Parse changelog
         id: parse_changelog
         run: |
@@ -48,6 +49,7 @@ jobs:
           echo '"EOT"' >> $GITHUB_OUTPUT
           echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
+        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           poetry run changelog2version \
             --changelog_file changelog.md \
@@ -57,9 +59,11 @@ jobs:
             --debug
           poetry build
       - name: Test built package
+        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         run: |
           twine check dist/*.tar.gz
       - name: Archive build package artifact
+        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: actions/upload-artifact@v4
         with:
           # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
@@ -68,6 +72,7 @@ jobs:
           path: dist/*.tar.gz
           retention-days: 14
       - name: Publish package
+        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           repository_url: https://test.pypi.org/legacy/
@@ -76,6 +81,7 @@ jobs:
           verbose: true
           print_hash: true
       - name: Create Prerelease
+        if: ! ${{ contains(fromJson(env.CHANGELOG_JSON).info.meta.scope, 'internal') }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -35,9 +35,6 @@ jobs:
             changelog changelog.md \
             --snippets=.snippets \
             --dry-run > latest-entry.json
-          jq -r ".content" latest-entry.json > latest_description.txt
-          sed -i '/^$/d' latest_description.txt
-          echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -35,9 +35,19 @@ jobs:
             changelog changelog.md \
             --snippets=.snippets \
             --dry-run > latest-entry.json
-          jq -r ".content" latest-entry.json > latest_description.txt
           cat latest-entry.json
-          cat latest_description.txt
+          cat latest-entry.json | python -c "import sys, json; print(json.load(sys.stdin)['content'])" > latest_description.txt
+
+          # jq -r ".content" latest-entry.json > latest_description.txt
+          # sed -i '/^$/d' latest_description.txt
+          # echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
+
+          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
+          cat latest_description.txt >> $GITHUB_OUTPUT
+          echo '"EOT"' >> $GITHUB_OUTPUT
+          # echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
+
+          exit 128
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -35,19 +35,13 @@ jobs:
             changelog changelog.md \
             --snippets=.snippets \
             --dry-run > latest-entry.json
-          cat latest-entry.json
-          cat latest-entry.json | python -c "import sys, json; print(json.load(sys.stdin)['content'])" > latest_description.txt
-
-          # jq -r ".content" latest-entry.json > latest_description.txt
-          # sed -i '/^$/d' latest_description.txt
-          # echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
-
+          jq -r ".content" latest-entry.json > latest_description.txt
+          sed -i '/^$/d' latest_description.txt
+          echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
           echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
           cat latest_description.txt >> $GITHUB_OUTPUT
           echo '"EOT"' >> $GITHUB_OUTPUT
-          # echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
-
-          exit 128
+          echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \

--- a/.snippets/23.md
+++ b/.snippets/23.md
@@ -7,4 +7,4 @@ affected: all
 
 - Document `--no-internal` option in `README`
 - Use `jq` instead of complex Python based `changelog.json` parsing in `release` and `test-release` workflows
-- Skip building, testing, publishing and creating (pre)releases if the latest change was marked as `internal`
+- Skip publishing and creating (pre)releases if the latest change was marked as `internal`

--- a/.snippets/23.md
+++ b/.snippets/23.md
@@ -7,3 +7,4 @@ affected: all
 
 - Document `--no-internal` option in `README`
 - Use `jq` instead of complex Python based `changelog.json` parsing in `release` and `test-release` workflows
+- Skip building, testing, publishing and creating (pre)releases if the latest change was marked as `internal`

--- a/.snippets/23.md
+++ b/.snippets/23.md
@@ -1,0 +1,9 @@
+## Document and use no-internal option
+<!--
+type: feature
+scope: internal
+affected: all
+-->
+
+- Document `--no-internal` option in `README`
+- Use `jq` instead of complex Python based `changelog.json` parsing in `release` and `test-release` workflows

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ changelog, use `--dry-run` to print the latest snippet content in JSON format.
 }
 ```
 
+The option `--no-internal` ignores all snippets with scope `internal` during
+the changelog generation. This is useful if those changes are not affecting
+the "product" like internal documentation changes or similar things, which e.g.
+do not require a deployment.
+
 ### Parse
 
 Parse an existing snippet file and return the data as JSON without indentation
@@ -184,7 +189,8 @@ jobs:
           changelog-generator \
             changelog changelog.md \
             --snippets=.snippets \
-            --in-place
+            --in-place \
+            --no-internal
 ```
 
 #### Other
@@ -194,7 +200,8 @@ pip install snippets2changelog
 changelog-generator \
   changelog changelog.md \
   --snippets=.snippets \
-  --in-place
+  --in-place \
+  --no-internal
 ```
 
 ## Contributing
@@ -247,6 +254,12 @@ not require any changes by the user to keep the system running after upgrading.
 - `breaking` creates a breaking, non backwards compatible change which
 requires the user to perform additional tasks, adopt his currently running
 code or in general can't be used as is anymore.
+
+The scope of a change shall either be:
+- `internal` if no new deployment is required for this change, like updates in
+the documentation for example
+- `external` or `all` if this change affects the public API of this package or
+requires a new tag and deployment for any other reason
 
 The changelog entry shall be short but meaningful and can of course contain
 links and references to other issues or PRs. New lines are only allowed for a

--- a/snippets2changelog/collector.py
+++ b/snippets2changelog/collector.py
@@ -43,7 +43,7 @@ class HistoryWalker(object):
         try:
             return str(self._repo.active_branch)
         except Exception as e:
-            print(f"HEAD is detached: {e}")
+            # print(f"HEAD is detached: {e}")
             return str(self._repo.head.commit.hexsha)
 
     @property


### PR DESCRIPTION
- Document `--no-internal` option in `README`
- Use `jq` instead of complex Python based `changelog.json` parsing in `release` and `test-release` workflows
- Skip building, testing, publishing and creating (pre)releases if the latest change was marked as `internal`
