### PR TITLE
Dry run option to print latest changelog entry

### DIFF
--- a/.snippets/27.md
+++ b/.snippets/27.md
@@ -1,0 +1,8 @@
+## Dry run option to print latest changelog entry
+<!--
+type: feature
+scope: all
+affected: all
+-->
+
+Use `--dry-run` with the `changelog` subparser to print the latest changelog entry as JSON instead of updating the changelog file.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ version entries and version bumps multiple times otherwise.*
 changelog-generator changelog changelog.md --snippets=.snippets [--in-place]
 ```
 
+To just get the latest changelog entry without updating or generating the
+changelog, use `--dry-run` to print the latest snippet content in JSON format.
+
+```json
+{
+    "version": "1.5.0",
+    "timestamp": "2024-10-12T13:36:46+02:00",
+    "meta": {
+        "type": "feature",
+        "scope": [
+            "all"
+        ],
+        "affected": [
+            "all"
+        ]
+    },
+    "content": "\n\nUse `--dry-run` with the `changelog` subparser to print the latest changelog entry as JSON instead of updating the changelog file.\n",
+    "version_reference": "https://github.com/brainelectronics/snippets2changelog/tree/1.5.0"
+}
+```
+
 ### Parse
 
 Parse an existing snippet file and return the data as JSON without indentation

--- a/snippets2changelog/cli.py
+++ b/snippets2changelog/cli.py
@@ -75,6 +75,11 @@ def parse_args(argv: Union[Sequence[str], None] = None) -> Args:
         action='store_true',
         help="Skip snippets with scope set as 'internal'",
     )
+    parser_changelog.add_argument(
+        "--dry-run",
+        action='store_true',
+        help="Print latest changelog entry as JSON instead of updating the changelog file",
+    )
 
     parser_create = subparsers.add_parser(
         "create",
@@ -125,7 +130,7 @@ def fn_info(_args: Args) -> None:
 
 def fn_changelog(args: Args) -> None:
     cc = ChangelogCreator(changelog=args.changelog, snippets_folder=args.snippets, update_in_place=args.in_place, skip_internal=args.no_internal, verbosity=args.verbose)
-    cc.update_changelog()
+    cc.update_changelog(dry_run=args.dry_run)
 
 
 def fn_create(args: Args) -> None:


### PR DESCRIPTION
Use `--dry-run` with the `changelog` subparser to print the latest changelog entry as JSON instead of updating the changelog file.