### PR TITLE
remove print from detached HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,7 @@ jobs:
             changelog changelog.md \
             --snippets=.snippets \
             --dry-run > latest-entry.json
-          jq -r ".content" latest-entry.json > latest_description.txt
-          sed -i '/^$/d' latest_description.txt
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
-          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          cat latest_description.txt >> $GITHUB_OUTPUT
-          echo '"EOT"' >> $GITHUB_OUTPUT
-          echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \
@@ -52,6 +46,19 @@ jobs:
             --snippets=.snippets \
             --in-place \
             --no-internal
+
+          poetry run changelog2version \
+            --changelog_file changelog.md \
+            --output changelog.json \
+            --print \
+            --debug
+
+          jq -r ".info.description" changelog.json > latest_description.txt
+          sed -i '/^$/d' latest_description.txt
+          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
+          cat latest_description.txt >> $GITHUB_OUTPUT
+          echo '"EOT"' >> $GITHUB_OUTPUT
+          echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
         run: |
           poetry run changelog2version \

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -35,13 +35,7 @@ jobs:
             changelog changelog.md \
             --snippets=.snippets \
             --dry-run > latest-entry.json
-          jq -r ".content" latest-entry.json > latest_description.txt
-          sed -i '/^$/d' latest_description.txt
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
-          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
-          cat latest_description.txt >> $GITHUB_OUTPUT
-          echo '"EOT"' >> $GITHUB_OUTPUT
-          echo "latest_version=$(jq -r '.version' latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
         run: |
           poetry run changelog-generator \
@@ -49,6 +43,19 @@ jobs:
             --snippets=.snippets \
             --in-place \
             --no-internal
+
+          poetry run changelog2version \
+            --changelog_file changelog.md \
+            --output changelog.json \
+            --print \
+            --debug
+
+          jq -r ".info.description" changelog.json > latest_description.txt
+          sed -i '/^$/d' latest_description.txt
+          echo 'LATEST_DESCRIPTION<<"EOT"' >> $GITHUB_OUTPUT
+          cat latest_description.txt >> $GITHUB_OUTPUT
+          echo '"EOT"' >> $GITHUB_OUTPUT
+          echo "latest_version=$(jq -r '.info.version' changelog.json)" >> $GITHUB_ENV
       - name: Build package
         run: |
           poetry run changelog2version \

--- a/.snippets/29.md
+++ b/.snippets/29.md
@@ -1,0 +1,8 @@
+## Remove print in branch property of HistoryWalker
+<!--
+type: bugfix
+scope: all
+affected: all
+-->
+
+Using the `branch` property of `HistoryWalker` in `collector.py` would print `HEAD is detached: ...` in case the HEAD is detached during a pull request build. This could lead to errors while creating a changelog with `--dry-run` and passing the output to a supposed JSON file, being finally unable to parse it as with that detached HEAD output it's not a JSON anymore.

--- a/snippets2changelog/collector.py
+++ b/snippets2changelog/collector.py
@@ -43,7 +43,7 @@ class HistoryWalker(object):
         try:
             return str(self._repo.active_branch)
         except Exception as e:
-            # print(f"HEAD is detached: {e}")
+            # HEAD is detached
             return str(self._repo.head.commit.hexsha)
 
     @property


### PR DESCRIPTION
Using the `branch` property of `HistoryWalker` in `collector.py` would print `HEAD is detached: ...` in case the HEAD is detached during a pull request build. This could lead to errors while creating a changelog with `--dry-run` and passing the output to a supposed JSON file, being finally unable to parse it as with that detached HEAD output it's not a JSON anymore.
