### PR TITLE
update release body with correct content again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
             --dry-run > latest-entry.json
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
+        id: update_changelog
         run: |
           poetry run changelog-generator \
             changelog changelog.md \
@@ -83,6 +84,6 @@ jobs:
         with:
           tag_name: ${{ env.latest_version }}
           release_name: ${{ env.latest_version }}
-          body: ${{ steps.parse_changelog.outputs.LATEST_DESCRIPTION }}
+          body: ${{ steps.update_changelog.outputs.LATEST_DESCRIPTION }}
           draft: false
           prerelease: false

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -37,6 +37,7 @@ jobs:
             --dry-run > latest-entry.json
           echo "CHANGELOG_JSON=$(jq -c . < latest-entry.json)" >> $GITHUB_ENV
       - name: Update changelog with snippets
+        id: update_changelog
         run: |
           poetry run changelog-generator \
             changelog changelog.md \
@@ -93,6 +94,6 @@ jobs:
         with:
           tag_name: ${{ env.latest_version }}-rc${{ github.run_number }}.dev${{ github.event.number }}
           release_name: ${{ env.latest_version }}-rc${{ github.run_number }}.dev${{ github.event.number }}
-          body: ${{ steps.parse_changelog.outputs.LATEST_DESCRIPTION }}
+          body: ${{ steps.update_changelog.outputs.LATEST_DESCRIPTION }}
           draft: false
           prerelease: true

--- a/.snippets/31.md
+++ b/.snippets/31.md
@@ -1,0 +1,8 @@
+## Fill release body correctly
+<!--
+type: bugfix
+scope: internal
+affected: all
+-->
+
+With [1.5.1](https://github.com/brainelectronics/snippets2changelog/tree/1.5.1) the changelog parsing and generation has been splitted up, but the location of the output for the release body has not been moved accordingly.


### PR DESCRIPTION
With [1.5.1](https://github.com/brainelectronics/snippets2changelog/tree/1.5.1) the changelog parsing and generation has been splitted up, but the location of the output for the release body has not been moved accordingly. This fixes #31