### PR TITLE
Set correct release candidate number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,17 @@ jobs:
           draft: false
           prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Create changelog based release'
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
+        uses: brainelectronics/changelog-based-release@v1.2.3
+        with:
+          # note you'll typically need to create a personal access token
+          # with permissions to create releases in the other repo
+          # or you set the "contents" permissions to "write" as in this example
+          changelog-path: changelog.md
+          tag-name-prefix: ''
+          tag-name-extension: ''
+          release-name-prefix: ''
+          release-name-extension: ''
+          draft-release: true
+          prerelease: false

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -19,6 +19,48 @@ jobs:
         with:
           # all history is needed to crawl it properly
           fetch-depth: 0
+      - name: Count run number
+        id: count
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("This workflow must be triggered by a pull request.");
+              return;
+            }
+
+            const pr_number = pr.number;
+            const workflow_name = context.workflow;
+            const branch_name = pr.head.ref;
+            const event_match = "pull_request";
+            console.log("PR Number: " + pr_number);
+            console.log("Workflow name: " + workflow_name);
+            console.log("Branch name: " + branch_name);
+
+            if (!pr_number) {
+              console.log("No pull request number found in context.");
+              core.setOutput("count", 0);
+              return;
+            }
+
+            const runs = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: event_match,
+              branch: branch_name,
+              per_page: 100
+            });
+
+            const filtered = runs.data.workflow_runs.filter(run =>
+              run.name === workflow_name &&
+              run.event === event_match &&
+              run.pull_requests?.some(p => p.number === pr_number)
+            );
+            console.log("Matches for filters aka runs: " + filtered.length);
+
+            const count = filtered.length > 0 ? filtered.length : 1;
+            core.setOutput("rc_number", count);
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -86,13 +128,17 @@ jobs:
           skip_existing: true
           verbose: true
           print_hash: true
-      - name: Create Prerelease
-        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
-        uses: softprops/action-gh-release@v2
+      - name: 'Create changelog based prerelease'
+        # if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
+        uses: brainelectronics/changelog-based-release@v1.2.2
         with:
-          tag_name: ${{ env.latest_version }}-rc${{ github.run_number }}.dev${{ github.event.number }}
-          name: ${{ env.latest_version }}-rc${{ github.run_number }}.dev${{ github.event.number }}
-          body: ${{ steps.update_changelog.outputs.LATEST_DESCRIPTION }}
-          draft: false
+          # note you'll typically need to create a personal access token
+          # with permissions to create releases in the other repo
+          # or you set the "contents" permissions to "write" as in this example
+          changelog-path: changelog.md
+          tag-name-prefix: ''
+          tag-name-extension: '-rc${{ steps.count.outputs.rc_number }}.dev${{ github.event.number }}'
+          release-name-prefix: ''
+          release-name-extension: '-rc${{ steps.count.outputs.rc_number }}.dev${{ github.event.number }}'
+          draft-release: true
           prerelease: true
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -129,7 +129,7 @@ jobs:
           verbose: true
           print_hash: true
       - name: 'Create changelog based prerelease'
-        # if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
+        if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
         uses: brainelectronics/changelog-based-release@v1.2.3
         with:
           # note you'll typically need to create a personal access token

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -130,7 +130,7 @@ jobs:
           print_hash: true
       - name: 'Create changelog based prerelease'
         # if: ${{ !contains(fromJson(env.CHANGELOG_JSON).meta.scope, 'internal') }}
-        uses: brainelectronics/changelog-based-release@v1.2.2
+        uses: brainelectronics/changelog-based-release@v1.2.3
         with:
           # note you'll typically need to create a personal access token
           # with permissions to create releases in the other repo

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -105,7 +105,7 @@ jobs:
             --changelog_file changelog.md \
             --version_file snippets2changelog/version.py \
             --version_file_type py \
-            --additional_version_info="-rc${{ github.run_number }}.dev${{ github.event.number }}" \
+            --additional_version_info="-rc${{ steps.count.outputs.rc_number }}.dev${{ github.event.number }}" \
             --debug
           poetry build
       - name: Test built package
@@ -116,7 +116,7 @@ jobs:
         with:
           # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           # ${{ github.repository }} and ${{ github.ref_name }} can't be used for artifact name due to unallowed '/'
-          name: dist_py.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
+          name: dist_py.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ steps.count.outputs.rc_number }}
           path: dist/*.tar.gz
           retention-days: 14
       - name: Publish package

--- a/.snippets/38.md
+++ b/.snippets/38.md
@@ -1,0 +1,10 @@
+## Set correct release candidate number
+<!--
+type: bugfix
+scope: internal
+affected: all
+-->
+
+This change creates the correct release candidate number based on the action run of a pull request workflow run `test-release` instead of the total number of this workflow run. By this fix, the `-rcX` metadata starts at `1` and is incremented with every push, no matter if the push is a force push or a classic new commit on top in a ongoing pull request.
+
+This closes [#38](https://github.com/brainelectronics/snippets2changelog/issues/38)


### PR DESCRIPTION
This change creates the correct release candidate number based on the action run of a pull request workflow run `test-release` instead of the total number of this workflow run. By this fix, the `-rcX` metadata starts at `1` and is incremented with every push, no matter if the push is a force push or a classic new commit on top in a ongoing pull request.

This closes [#38](https://github.com/brainelectronics/snippets2changelog/issues/38)